### PR TITLE
add deposit calculate

### DIFF
--- a/src/main/kotlin/lesson_2/task_5.kt
+++ b/src/main/kotlin/lesson_2/task_5.kt
@@ -1,0 +1,13 @@
+package lesson_2
+
+import kotlin.math.pow
+
+fun main() {
+    val depositAmount = 70_000
+    val percentYear = 16.7
+    val term = 20
+
+    val result = String.format("%.3f", depositAmount * (1+(percentYear/100)).pow(term))
+
+    println(result)
+}


### PR DESCRIPTION
А тут переменная для процента, если представить что процент будет не дробным, то лучше явно в выражении привести его к Double, чтобы pow не поломалось? Именно не переменную а в вычисляемом выражении, т.к если переменную привести, то туда не сможем записать целое число, ну если конечно с сервера не будет приходить в виде 7.0 16.0 и тд, то тогда можно без явного определения типа.